### PR TITLE
teams: Initialize Special Interest Groups

### DIFF
--- a/teams/sig-api.yaml
+++ b/teams/sig-api.yaml
@@ -1,0 +1,13 @@
+name: sig-api
+description: Unikraft APIs Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+
+reviewers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew

--- a/teams/sig-arch-arm.yaml
+++ b/teams/sig-arch-arm.yaml
@@ -1,0 +1,19 @@
+name: sig-arch-arm
+description: Unikraft ARM Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+  - name: Michalis Pappas
+    github: michpappas
+
+reviewers:
+  - name: Răzvan Vîrtan
+    github: razvanvirtan
+  - name: Renê de Souza Pinto
+    github: rene
+  - name: Jia He
+    github: justin-he
+  - name: Jianyong Wu
+    github: jongwu

--- a/teams/sig-arch-x86.yaml
+++ b/teams/sig-arch-x86.yaml
@@ -1,0 +1,15 @@
+name: sig-arch-x86
+description: Unikraft Intel x86 Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+
+reviewers:
+  - name: Vlad-Andrei Badoiu
+    github: vladandrew
+  - name: Cristian Vijelie
+    github: cristian-vijelie
+  - name: Cyril Soldani
+    github: cffs

--- a/teams/sig-arch.yaml
+++ b/teams/sig-arch.yaml
@@ -1,0 +1,9 @@
+name: sig-arch
+description: Unikraft Architectures Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+  - name: Marc Rittinghaus
+    github: marcrittinghaus

--- a/teams/sig-build.yaml
+++ b/teams/sig-build.yaml
@@ -1,0 +1,17 @@
+name: sig-build
+description: Unikraft Build System Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Alexander Jung
+    github: nderjung
+  - name: Simon Kuenzer
+    github: skuenzer
+
+reviewers:
+  - name: Cezar Craciunoiu
+    github: craciunoiuc
+  - name: Adina Smeu
+    github: adinasm
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew

--- a/teams/sig-cicd.yaml
+++ b/teams/sig-cicd.yaml
@@ -1,0 +1,13 @@
+name: sig-cicd
+description: Unikraft CI/CD Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Alexander Jung
+    github: nderjung
+
+reviewers:
+  - name: Gabriel Mocanu
+    github: gabrielmocanu
+  - name: Cristian Vijelie
+    github: cristian-vijelie

--- a/teams/sig-core.yaml
+++ b/teams/sig-core.yaml
@@ -1,0 +1,15 @@
+name: sig-core
+description: Unikraft Core Team
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+  - name: Alexander Jung
+    github: nderjung
+  - name: Felipe Huici
+    github: felipehuici
+  - name: Răzvan Deaconescu
+    github: razvand
+  - name: Marc Rittinghaus
+    github: marcrittinghaus

--- a/teams/sig-debug.yaml
+++ b/teams/sig-debug.yaml
@@ -1,0 +1,13 @@
+name: sig-debug
+description: Unikraft Debug Tools Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+  - name: Simon Kuenzer
+    github: skuenzer
+
+reviewers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew

--- a/teams/sig-device.yaml
+++ b/teams/sig-device.yaml
@@ -1,0 +1,15 @@
+name: sig-device
+description: Unikraft Device Drivers Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+
+reviewers:
+  - name: Andreea Dumitrache
+    github: andreeaDumitrache29
+  - name: Răzvan Vîrtan
+    github: razvanvirtan

--- a/teams/sig-fs.yaml
+++ b/teams/sig-fs.yaml
@@ -1,0 +1,15 @@
+name: sig-fs
+description: Unikraft Filesystems Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+  - name: Simon Kuenzer
+    github: skuenzer
+
+reviewers:
+  - name: Marco Schlumpp
+    github: mschlumpp
+  - name: Dragoș Argint
+    github: dragosargint

--- a/teams/sig-lang-rust.yaml
+++ b/teams/sig-lang-rust.yaml
@@ -1,0 +1,15 @@
+name: sig-lang-rust
+description: Unikraft Rust Language Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+
+reviewers:
+  - name: Cyril Soldani
+    github: cffs
+  - name: Gaulthier Gain
+    github: gaulthiergain
+  - name: Dennis Kobert
+    github: TrueDoctor

--- a/teams/sig-lang.yaml
+++ b/teams/sig-lang.yaml
@@ -1,0 +1,17 @@
+name: sig-lang
+description: Unikraft Language Runtimes Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+
+reviewers:
+  - name: Răzvan Deaconescu
+    github: razvand
+  - name: Cristian Baciu
+    github: CristiBM
+  - name: Cyril Soldani
+    github: cffs

--- a/teams/sig-libc.yaml
+++ b/teams/sig-libc.yaml
@@ -1,0 +1,15 @@
+name: sig-libc
+description: Unikraft Standard Library (libc) Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Cyril Soldani
+    github: cffs
+  - name: Gaulthier Gain
+    github: gaulthiergain
+
+reviewers:
+  - name: Dragoș Argint
+    github: dragosargint
+  - name: Sergiu Moga
+    github: mogasergiu

--- a/teams/sig-mem.yaml
+++ b/teams/sig-mem.yaml
@@ -1,0 +1,13 @@
+name: sig-mem
+description: Unikraft Memory Management Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Hugo Lefeuvre
+    github: hlef
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+
+reviewers:
+  - name: Cezar Craciunoiu
+    github: craciunoiuc

--- a/teams/sig-net.yaml
+++ b/teams/sig-net.yaml
@@ -1,0 +1,17 @@
+name: sig-net
+description: Unikraft Networking Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+  - name: Alexander Jung
+    github: nderjung
+
+reviewers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+  - name: Costin Lupu
+    github: clupuishere
+  - name: Hugo Lefeuvre
+    github: hlef

--- a/teams/sig-plat-kvm.yaml
+++ b/teams/sig-plat-kvm.yaml
@@ -1,0 +1,17 @@
+name: sig-plat-kvm
+description: Unikraft KVM Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+  - name: Simon Kuenzer
+    github: skuenzer
+
+reviewers:
+  - name: Cristian Vijelie
+    github: cristian-vijelie
+  - name: Sergiu Moga
+    github: mogasergiu
+  - name: Gabriel Mocanu
+    github: gabrielmocanu

--- a/teams/sig-plat-linuxu.yaml
+++ b/teams/sig-plat-linuxu.yaml
@@ -1,0 +1,15 @@
+name: sig-plat-linuxu
+description: Unikraft Linux Userspace Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+  - name: Răzvan Deaconescu
+    github: razvand
+
+reviewers:
+  - name: Sergiu Moga
+    github: mogasergiu
+  - name: Daniel Dincă
+    github: danield20

--- a/teams/sig-plat-xen.yaml
+++ b/teams/sig-plat-xen.yaml
@@ -1,0 +1,13 @@
+name: sig-plat-xen
+description: Unikraft Xen Hypervisor Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+
+reviewers:
+  - name: Costin Lupu
+    github: clupuishere
+  - name: Gabriel Mocanu
+    github: gabrielmocanu

--- a/teams/sig-plat.yaml
+++ b/teams/sig-plat.yaml
@@ -1,0 +1,13 @@
+name: sig-plat
+description: Unikraft Platforms Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+  - name: Marc Rittinghaus
+    github: marcrittinghaus
+
+reviewers:
+  - name: Daniel Dincă
+    github: danield20

--- a/teams/sig-sched.yaml
+++ b/teams/sig-sched.yaml
@@ -1,0 +1,15 @@
+name: sig-sched
+description: Unikraft Schedulers Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Simon Kuenzer
+    github: skuenzer
+
+reviewers:
+  - name: Sergiu Moga
+    github: mogasergiu
+  - name: Dragoș Argint
+    github: dragosargint
+  - name: Daniel Dincă
+    github: danield20

--- a/teams/sig-security.yaml
+++ b/teams/sig-security.yaml
@@ -1,0 +1,13 @@
+name: sig-security
+description: Unikraft Security Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Hugo Lefeuvre
+    github: hlef
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+
+reviewers:
+  - name: Daniel Dincă
+    github: danield20

--- a/teams/sig-test.yaml
+++ b/teams/sig-test.yaml
@@ -1,0 +1,11 @@
+name: sig-test
+description: Unikraft Testing Special Interest Group
+privacy: closed
+
+maintainers:
+  - name: Alexander Jung
+    github: nderjung
+
+reviewers:
+  - name: Daniel Dinca
+    github: danield20


### PR DESCRIPTION
This commit introduces initial Special Interest Groups (SIGs) within the Unikraft OSS community.