### PR TITLE
Fix teams definitions

### DIFF
--- a/teams/sig-core.yaml
+++ b/teams/sig-core.yaml
@@ -7,12 +7,18 @@ maintainers:
     github: skuenzer
   - name: Alexander Jung
     github: nderjung
-  - name: Felipe Huici
-    github: felipehuici
   - name: Răzvan Deaconescu
     github: razvand
   - name: Marc Rittinghaus
     github: marcrittinghaus
+
+reviewers:
+  - name: Vlad-Andrei Bădoiu
+    github: vladandrew
+  - name: Cezar Craciunoiu
+    github: craciunoiuc
+  - name: Dragoș Argint
+    github: dragosargint
 
 repos:
   - name: unikraft

--- a/teams/sig-fs.yaml
+++ b/teams/sig-fs.yaml
@@ -17,5 +17,5 @@ reviewers:
 repos:
   - name: lib-extfs
   - name: lib-fatfs
-  - name: lib-naivefs
+  - name: lib-niavefs
   - name: lib-shfs

--- a/teams/sig-libc.yaml
+++ b/teams/sig-libc.yaml
@@ -30,7 +30,7 @@ repos:
   - name: lib-libjpeg
   - name: lib-libm
   - name: lib-libpng
-  - name: lib-libtff
+  - name: lib-libtiff
   - name: lib-libucontext
   - name: lib-libunwind
   - name: lib-libuuid

--- a/teams/sig-security.yaml
+++ b/teams/sig-security.yaml
@@ -16,6 +16,5 @@ repos:
   - name: lib-axtls
   - name: lib-libhogweed
   - name: lib-libsodium
-  - name: lib-tsan1
   - name: lib-mbedtls
   - name: lib-openssl


### PR DESCRIPTION
This PR remove Felipe Huici as a maintainer of the core team
such that he is not added to PRs during automatic assignment of
reviewers and approvers.

This PR also introduces Vlad, Cezar and Dragos as reviewers to
all core repositories.

This PR also fixes invalid team names and remove non-existent

Signed-off-by: Alexander Jung <a.jung@lancs.ac.uk>