### PR TITLE
labels: Initial copy from Unikraft main repo

### DIFF
--- a/labels/arch.yaml
+++ b/labels/arch.yaml
@@ -1,0 +1,31 @@
+labels:
+  - name: arch/arm
+    description: Issues and PRs related to ARM architecture
+    color: "#1d76db"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - arch/arm/**
+      - plat/common/arm/**
+      - plat/common/include/arm/**
+
+  - name: arch/arm64
+    description: Issues and PRs related to ARM 64-bit architecture
+    color: "#1d76db"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - arch/arm/arm64/**
+      - plat/common/arm/*64.S
+      - plat/common/arm/*64.c
+      - plat/common/include/arm/arm64/**
+
+  - name: arch/x86_64
+    description: Issues and PRs related to Intel x86_64 architecture
+    color: "#c5def5"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - arch/x86/**
+      - plat/common/x86/**
+      - plat/common/include/x86/**

--- a/labels/area.yaml
+++ b/labels/area.yaml
@@ -1,0 +1,64 @@
+labels:
+  - name: area/arch
+    description: Issues and PRs which affect architecture code
+    color: "#7ec2f7"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - arch/**
+
+  - name: area/docs
+    description: Issues and PRs which affect documentation
+    color: "#db4eb8"
+    apply_on_pr_match_paths:
+      - doc/**
+      - README.md
+
+  - name: area/exportsyms
+    description: Issue or PR relates to exporting symbols from a library
+    color: "#f9822c"
+    apply_on_pr_match_paths:
+      - exportsyms.uk
+
+  - name: area/include
+    description: Issues and PRs which affect headers
+    color: "#e99695"
+    apply_on_pr_match_paths:
+      - include/**
+
+  - name: area/kconfig
+    description: Issues and PRs which affect KConfig code
+    color: "#ed8ebd"
+    apply_on_pr_match_paths:
+      - Config.uk
+
+  - name: area/lib
+    description: Issues and PRs which affect internal Unikraft libraries
+    color: "#ed8ebd"
+    match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/**
+
+  - name: area/makefile
+    description: Issues and PRs which affect Makefile code
+    color: "#ffe5c9"
+    apply_on_pr_match_paths:
+      - Makefile.uk
+      - Makefile
+
+  - name: area/plat
+    description: Issues and PRs which affect platform code
+    color: "#f2daa9"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/**
+
+  - name: area/support
+    description: Issues and PRs which affect support code
+    color: "#bfd4f2"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - suuport/**

--- a/labels/arm.yaml
+++ b/labels/arm.yaml
@@ -1,0 +1,10 @@
+labels:
+  - name: arm/smcc
+    description: Secure Monitor Call Calling Convention on ARM
+    color: "#0BA2F3"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - include/uk/arch/arm/smccc.h
+      - plat/common/arm/smccc.c
+      - plat/common/arm/smccc_invoke.S

--- a/labels/bug.yaml
+++ b/labels/bug.yaml
@@ -1,0 +1,16 @@
+labels:
+  - name: bug/compile-time
+    description: Bug occurs during compile-time
+    color: "#ed5139"
+
+  - name: bug/link-time
+    description: Bug occurs during link-time
+    color: "#884239"
+
+  - name: bug/runtime
+    description: Bug occurs during runtime
+    color: "#4d2a25"
+
+  - name: bug/fix
+    description: This PR fixes a bug
+    color: "#4bcc7a"

--- a/labels/ci.yaml
+++ b/labels/ci.yaml
@@ -1,0 +1,8 @@
+labels:
+  - name: ci/merged
+    description: Merged by CI
+    color: "#d4c5f9"
+
+  - name: ci/wait
+    description: Tell the CI system to wait before performing any action.
+    color: "#e99695"

--- a/labels/kind.yaml
+++ b/labels/kind.yaml
@@ -1,0 +1,28 @@
+labels:
+  - name: kind/bug
+    description: Something isn't working
+    color: "#d73a4a"
+
+  - name: kind/enhancement
+    description: Issues and PRs related to increasing functionality
+    color: "#a2eeef"
+
+  - name: kind/maintenance
+    description: Chores and meta-tasks
+    color: "#a295d6"
+
+  - name: kind/project
+    description: Issue is a substantial contribution
+    color: "#008672"
+
+  - name: kind/proposal
+    description: Issue discusses potential new feature or change
+    color: "#dd75c0"
+
+  - name: kind/question
+    description: Issue asks a question
+    color: "#e99695"
+
+  - name: kind/quick-fix
+    description: Issue or PR is related to a quick fix
+    color: "#1daf6b"

--- a/labels/lang.yaml
+++ b/labels/lang.yaml
@@ -1,0 +1,66 @@
+labels:
+  - name: lang/c
+    description: Issues or PRs which affect code written in C
+    color: "#bbbbbb"
+    apply_on_pr_match_paths:
+      - "**/*\\.c"
+
+  - name: lang/cpp
+    description: Issues or PRs which affect code written in C++
+    color: "#bbbbbb"
+    apply_on_pr_match_paths:
+      - "**/*\\.cpp"
+
+  - name: lang/d
+    description: Issues or PRs which affect code written in Dlang
+    color: "#9f2725"
+    apply_on_pr_match_paths:
+      - "**/*\\.d"
+
+  - name: lang/go
+    description: Issues or PRs which affect code written in Golang
+    color: "#58c7d6"
+    apply_on_pr_match_paths:
+      - "**/*\\.go"
+
+  - name: lang/javascript
+    description: Issues or PRs which affect code written in JavaScript
+    color: "#e1cf27"
+    apply_on_pr_match_paths:
+      - "**/*\\.js"
+
+  - name: lang/lua
+    description: Issues or PRs which affect code written in Lua
+    color: "#000069"
+    apply_on_pr_match_paths:
+      - "**/*\\.lua"
+
+  - name: lang/php
+    description: Issues or PRs which affect code written in PHP
+    color: "#60619d"
+    apply_on_pr_match_paths:
+      - "**/*\\.php"
+
+  - name: lang/python
+    description: Issues or PRs which affect code written in Python
+    color: "#2b5f95"
+    apply_on_pr_match_paths:
+      - "**/*\\.py"
+
+  - name: lang/ruby
+    description: Issues or PRs which affect code written in Ruby
+    color: "#a80007"
+    apply_on_pr_match_paths:
+      - "**/*\\.rb"
+
+  - name: lang/rust
+    description: Issues or PRs which affect code written in Rust
+    color: "#8a4521"
+    apply_on_pr_match_paths:
+      - "**/*\\.rs"
+
+  - name: lang/wamr
+    description: Issues or PRs which affect code written in WAMR
+    color: "#5130ec"
+    apply_on_pr_match_paths:
+      - "**/*\\.wamr"

--- a/labels/lib.yaml
+++ b/labels/lib.yaml
@@ -1,0 +1,304 @@
+labels:
+  - name: lib/9pfs
+    description: Issues and PRs which affect the 9p filesystem
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/9pfs/**
+
+  - name: lib/devfs
+    description: Issues and PRs which affect the devfs file system
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/devfs/**
+
+  - name: lib/fdt
+    description: Issues and PRs which affect Flat Device Tree manipulation
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/fdt/**
+
+  - name: lib/isrlib
+    description: Issues and PRs which affect interrupt-safe standard routines
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/isrlib/**
+
+  - name: lib/nolibc
+    description: Issues and PRs which affect the nolibc subset
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/nolibc/**
+
+  - name: lib/posix-libdl
+    description: Issues and PRs which affect POSIX libdl library
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/posix-libdl/**
+
+  - name: lib/posix-process
+    description: Issues and PRs which affect POSIX process-related functions
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/posix-process/**
+
+  - name: lib/posix-sysinfo
+    description: Issues and PRs which affect information about system parameters
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/posix-sysinfo/**
+
+  - name: lib/posix-user
+    description: Issues and PRs which affect POSIX user-related functions
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/posix-user/**
+
+  - name: lib/ramfs
+    description: Issues and PRs which affect the simple RAM file system
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ramfs/**
+
+  - name: lib/syscall_shim
+    description: Issues and PRs which affect the syscall shim layer
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/syscall_shim/**
+
+  - name: lib/ubsan
+    description: Issues and PRs which affect Undefined Behavior Sanitization
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ubsan/**
+
+  - name: lib/uk9p
+    description: Issues and PRs which affect the 9p client
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uk9p/**
+
+  - name: lib/ukalloc
+    description: Issues and PRs which affect the binary buddy page allocator
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukalloc/**
+
+  - name: lib/ukallocbbuddy
+    description: Issues and PRs which affect the abstraction for memory allocators
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukallocbbuddy/**
+
+  - name: lib/ukallocpool
+    description: Issues and PRs which affect the memory pool allocator
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukallocpool/**
+
+  - name: lib/ukallocregion
+    description: Issues and PRs which affect the region-based allocator
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukallocregion/**
+
+  - name: lib/ukargparse
+    description: Issues and PRs which affect the simple argument parser
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukargparse/**
+
+  - name: lib/ukblkdev
+    description: Issues and PRs which affect the block driver interface
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukblkdev/**
+
+  - name: lib/ukboot
+    description: Issues and PRs which affect the Unikraft bootstrapping code
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukboot/**
+
+  - name: lib/ukbus
+    description: Issues and PRs which affect the abstraction for device buses
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukbus/**
+
+  - name: lib/ukcpio
+    description: Issues and PRs which affect CPIO archive extraction
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukcpio/**
+
+  - name: lib/ukdebug
+    description: Issues and PRs which affect debugging and tracing
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukdebug/**
+
+  - name: lib/uklibparam
+    description: Issues and PRs which affect the library arguments parser
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uklibparam/**
+
+  - name: lib/uklock
+    description: Issues and PRs which affect multi-task synchronization primitives
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uklock/**
+
+  - name: lib/ukmmap
+    description: Issues and PRs which affect mmap system call
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukmmap/**
+
+  - name: lib/ukmpi
+    description: Issues and PRs which affect the Message Passing Interface
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukmpi/**
+
+  - name: lib/uknetdev
+    description: Issues and PRs which affect the network driver interface
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uknetdev/**
+
+  - name: lib/ukring
+    description: Issues and PRs which affect the ring buffer interface
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukring/**
+
+  - name: lib/uksched
+    description: Issues and PRs which affect the abstraction for schedulers
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uksched/**
+
+  - name: lib/ukschedcoop
+    description: Issues and PRs which affect the cooperative Round-Robin scheduler
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukschedcoop/**
+
+  - name: lib/uksglist
+    description: Issues and PRs which affect the Scatter Gather List
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uksglist/**
+
+  - name: lib/uksignal
+    description: Issues and PRs which affect Unikraft signals
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uksignal/**
+
+  - name: lib/uksp
+    description: Issues and PRs which affect the stack protector
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uksp/**
+
+  - name: lib/ukswrand
+    description: Issues and PRs which affect the software random number generator
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/ukswrand/**
+
+  - name: lib/uktime
+    description: Issues and PRs which affect time functions
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uktime/**
+
+  - name: lib/uktimeconv
+    description: Issues and PRs which affect time conversion functions
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/uktimeconv/**
+
+  - name: lib/vfscore
+    description: Issues and PRs which affect VFS Core interface
+    color: "#fbca04"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - lib/vfscore/**

--- a/labels/lifecycle.yaml
+++ b/labels/lifecycle.yaml
@@ -1,0 +1,27 @@
+labels:
+  - name: lifecycle/active
+    description: Indicates that an issue or PR is actively being worked on by a contributor
+    color: "#8ee234"
+    apply_after: 0s
+    remove_after: 720h # 30 days
+    do_not_remove_if_labels_exist:
+      - lifecycle/frozen
+
+  - name: lifecycle/stale
+    description: Denotes an issue or PR has remained open with no activity and has become stale
+    color: "#795548"
+    apply_after: 720h # 30 days
+    remove_after: 4320h # 180 days
+    do_not_remove_if_labels_exist:
+      - lifecycle/frozen
+
+  - name: lifecycle/rotten
+    description: Denotes an issue or PR that has aged beyond stale and will be auto-closed
+    color: "#795548"
+    apply_after: 4320h # 180 days
+    do_not_remove_if_labels_exist:
+      - lifecycle/frozen
+
+  - name: lifecycle/frozen
+    description: Indicates that an issue or PR should not be auto-closed due to staleness
+    color: "#b2fff6"

--- a/labels/misc.yaml
+++ b/labels/misc.yaml
@@ -1,0 +1,12 @@
+labels:
+  - name: good-first-issue
+    description: Good for newcomers
+    color: "#7057ff"
+
+  - name: patchwork-backlog
+    description: Migrated from patchwork.unikraft.org
+    color: "#bfd4f2"
+
+  - name: release-note
+    description: Issue or PR can aid in creating a release note
+    color: "#c2e0c6"

--- a/labels/needs.yaml
+++ b/labels/needs.yaml
@@ -1,0 +1,12 @@
+labels:
+  - name: needs/documentation
+    description: Issue or PR needs additional documentation
+    color: "#d4c5f9"
+
+  - name: needs/rebase
+    description: Indicates a PR cannot be merged because it has merge conflicts with HEAD
+    color: "#2e20c1"
+    apply_when:
+      - needs_rebase
+    remove_when:
+      - no_rebase

--- a/labels/new.yaml
+++ b/labels/new.yaml
@@ -1,0 +1,24 @@
+labels:
+  - name: new/library
+    description: Issues and PRs related to a new library
+    color: "#7bdb48"
+
+  - name: new/metric
+    description: Issues and PRs related to a new metric
+    color: "#7bdb48"
+
+  - name: new/posix-function
+    description: Issues and PRs related to a new POSIX function
+    color: "#7bdb48"
+
+  - name: new/primitive
+    description: Issues and PRs related to a new primitive
+    color: "#7bdb48"
+
+  - name: new/syscall
+    description: Issues and PRs related to a new syscall
+    color: "#7bdb48"
+
+  - name: new/test
+    description: Issues and PRs related to a new test
+    color: "#7bdb48"

--- a/labels/plat.yaml
+++ b/labels/plat.yaml
@@ -1,0 +1,110 @@
+labels:
+  - name: plat/common
+    description: Issues and PRs related to all platforms
+    color: "#1d76db"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/common/**
+      - include/uk/plat/common/**
+
+  - name: plat/driver/tap
+    description: Issues and PRs related to the tap driver
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/drivers/tap/**
+      - plat/drivers/include/tap/**
+      - plat/linuxu/tap_io.c
+
+  - name: plat/driver/virtio
+    description: Issues and PRs related to virtio drivers
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/drivers/virtio/**
+      - plat/drivers/include/virtio/**
+
+  - name: plat/driver/ofw
+    description: Issues and PRs related to open firmware drivers
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/drivers/ofw/**
+      - plat/drivers/include/ofw/**
+
+  - name: plat/driver/gic
+    description: Issues and PRs related to the GIC driver
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/drivers/gic/**
+      - plat/drivers/include/gic/**
+
+  - name: plat/driver/pci
+    description: Issues and PRs related to PCI driver
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/common/include/pci/**
+
+  - name: plat/driver/9p
+    description: Issues and PRs related to 9p driver
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/*/include/9p/**
+
+  - name: plat/driver/net
+    description: Issues and PRs related to network driver
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/*/include/net/**
+
+  - name: plat/driver/blk
+    description: Issues and PRs related to block driver
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/*/include/blk/**
+
+  - name: plat/driver
+    description: Issues and PRs related to platform drivers
+    color: "#750210"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/drivers/**
+
+  - name: plat/kvm
+    description: Issues and PRs related to KVM platform
+    color: "#1f8aa5"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/kvm/**
+
+  - name: plat/linuxu
+    description: Issues and PRs related to Linux Userspace platform
+    color: "#bfdadc"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/linux/**
+
+  - name: plat/xen
+    description: ssues and PRs related to the Xen platform
+    color: "#4da81f"
+    apply_on_pr_match_repos:
+      - unikraft
+    apply_on_pr_match_paths:
+      - plat/xen/**

--- a/labels/priority.yaml
+++ b/labels/priority.yaml
@@ -1,0 +1,16 @@
+labels:
+  - name: priority/high
+    description: Issues and PRs which have a high priority
+    color: "#d93f0b"
+
+  - name: priority/medium
+    description: Issues and PRs which have priority
+    color: "#eb9e34"
+
+  - name: priority/low
+    description: Issues and PRs which have a very low priority
+    color: "#A1CBD2"
+
+  - name: priority/nice-to-have
+    description: Issues and PRs which have a very low priority
+    color: "#FD93AC"

--- a/labels/state.yaml
+++ b/labels/state.yaml
@@ -1,0 +1,28 @@
+labels:
+  - name: state/accepted
+    description: Issue or PR has been accepted
+    color: "#BBFD97"
+
+  - name: state/action-required
+    description: Issue or PR requires external change to occur before proceeding
+    color: "#006b75"
+
+  - name: state/changes-requested
+    description: Issue or PR requires a change to proceed
+    color: "#FA7505"
+
+  - name: state/deferred
+    description: Issue or PR has been deferred
+    color: "#763F27"
+
+  - name: state/not-applicable
+    description: Issue or PR is not applicable
+    color: "#52544A"
+
+  - name: state/rejected
+    description: Sadly this issue or PR cannot be accepted
+    color: "#E93303"
+
+  - name: state/superceded
+    description: Issue or PR is no longer applicable
+    color: "#5024E8"

--- a/labels/topic.yaml
+++ b/labels/topic.yaml
@@ -1,0 +1,60 @@
+labels:
+  - name: topic/booting
+    description: Issue or PR pertaining to the boot process
+    color: "#c5def5"
+
+  - name: topic/build
+    description: Issue or PR pertaining to the build system
+    color: "#c5def5"
+
+  - name: topic/ci
+    description: Issue or PR pertaining to CI/CD
+    color: "#c5def5"
+
+  - name: topic/concurrency
+    description: Issue or PR pertaining to concurrency
+    color: "#c5def5"
+
+  - name: topic/irq
+    description: Issue or PR pertaining to IRQs
+    color: "#c5def5"
+
+  - name: topic/metrics
+    description: Issue or PR pertaining to metrics
+    color: "#c5def5"
+
+  - name: topic/mm
+    description: Issue or PR pertaining to memory management
+    color: "#c5def5"
+
+  - name: topic/mpk
+    description: Issue or PR pertaining to Memory Protection Keys (MPKs)
+    color: "#c5def5"
+
+  - name: topic/posix
+    description: Issue or PR pertaining to POSIX
+    color: "#c5def5"
+
+  - name: topic/primitive
+    description: Issue or PR pertaining to Unikraft primitives
+    color: "#c5def5"
+
+  - name: topic/scheduling
+    description: Issue or PR pertaining to scheduling
+    color: "#c5def5"
+
+  - name: topic/smp
+    description: Issue or PR pertaining to SMP
+    color: "#c5def5"
+
+  - name: topic/syscall
+    description: Issue or PR pertaining to syscalls
+    color: "#c5def5"
+
+  - name: topic/threading
+    description: Issue or PR pertaining to threading
+    color: "#c5def5"
+
+  - name: topic/tls
+    description: Issue or PR pertaining to Thread Local Storage (TLS)
+    color: "#c5def5"


### PR DESCRIPTION
This PR contains lists of all the known labels used on the GitHub repository for the Unikraft main repository.  It also includes the "inherent logic" that is used for them, so it can be later automated.