### PR TITLE
Rename LIBUKSWRAND to LIBUKRANDOM

### DIFF
--- a/config/labels/lib.yaml
+++ b/config/labels/lib.yaml
@@ -271,13 +271,13 @@ labels:
     apply_on_pr_match_paths:
       - lib/uksp/**
 
-  - name: lib/ukswrand
-    description: Issues and PRs which affect the software random number generator
+  - name: lib/ukrandom
+    description: Issues and PRs which affect the random number generator
     color: "#fbca04"
     apply_on_pr_match_repos:
       - unikraft
     apply_on_pr_match_paths:
-      - lib/ukswrand/**
+      - lib/ukrandom/**
 
   - name: lib/uktime
     description: Issues and PRs which affect time functions


### PR DESCRIPTION
This depends on https://github.com/unikraft/unikraft/pull/1008.